### PR TITLE
fix: existing habit edited instead of creating new one

### DIFF
--- a/lib/src/pages/create_or_edit_habit_page.dart
+++ b/lib/src/pages/create_or_edit_habit_page.dart
@@ -132,7 +132,9 @@ class _CreateOrEditHabitPageState extends State<CreateOrEditHabitPage> {
               LucideIcons.check,
               color: habitName.isNotEmpty ? Colors.white : Colors.grey,
             ),
-            onPressed: habitName.isNotEmpty ? createHabit : null,
+            onPressed: habitName.isNotEmpty
+                ? (widget.habit != null ? editHabit : createHabit)
+                : null,
           ),
           SizedBox(width: 8),
         ],


### PR DESCRIPTION
When editing a habit, a new one was being created instead.
Added null check for `widget.habit` to correctly call `editHabit()`.